### PR TITLE
Fix the default issue for ES6 imports with most

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ All of the examples below assume the same basic setup described in this tutorial
 Let's start by creating a very simple application and use a collection just to manage some predefined child components. The component examples below are overly simplistic of course, as we're just demonstrating a concept. In reality, sections of functionality would be broken out into separate components only when there is value to managing them independently.
 
 ```js
-import most from 'most';
+import * as most from 'most';
 import {run} from '@cycle/most-run';
 import {div, h1, header, main, nav, p, makeDOMDriver} from '@motorcycle/dom';
 import Collection from '@motorcycle/collection';

--- a/src/collection.js
+++ b/src/collection.js
@@ -1,4 +1,4 @@
-import most from 'most';
+import * as most from 'most';
 import hold from '@most/hold';
 import Immutable from 'immutable';
 import {combineArray, combineObject} from './statics';

--- a/src/statics.js
+++ b/src/statics.js
@@ -1,5 +1,5 @@
 import Immutable from 'immutable';
-import most from 'most';
+import * as most from 'most';
 import {isStream, isSinks} from './common';
 import {Collection} from './collection';
 import snapshot from './snapshot';

--- a/src/switch-collection.js
+++ b/src/switch-collection.js
@@ -25,7 +25,7 @@
      disposed and removed, and the new one is activated to replace the old one.
 */
 
-import most from 'most';
+import * as most from 'most';
 import Collection from './index';
 import {calculateDiff} from './diff';
 import {placeholderSymbol} from './common';

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -1,5 +1,5 @@
 import util from 'util';
-import most from 'most';
+import * as most from 'most';
 
 
 if(!console.inspect) {

--- a/test/test-add.js
+++ b/test/test-add.js
@@ -1,5 +1,5 @@
 import assert from 'power-assert';
-import most from 'most';
+import * as most from 'most';
 import Collection from '../src';
 
 describe('Collection', () => {

--- a/test/test-combine.js
+++ b/test/test-combine.js
@@ -1,5 +1,5 @@
 import assert from 'power-assert';
-import most from 'most';
+import * as most from 'most';
 import {run} from 'most-test';
 import Collection from '../src';
 import {isStream} from './helpers';

--- a/test/test-diff.js
+++ b/test/test-diff.js
@@ -1,5 +1,5 @@
 import assert from 'power-assert';
-import most from 'most';
+import * as most from 'most';
 import Collection from '../src';
 import {calculateDiff, compareItems, compareSinks} from '../src/diff';
 import {isStream} from './helpers';

--- a/test/test-merge.js
+++ b/test/test-merge.js
@@ -1,5 +1,5 @@
 import assert from 'power-assert';
-import most from 'most';
+import * as most from 'most';
 import {run} from 'most-test';
 import Collection from '../src';
 

--- a/test/test-set.js
+++ b/test/test-set.js
@@ -1,5 +1,5 @@
 import assert from 'power-assert';
-import most from 'most';
+import * as most from 'most';
 import Collection from '../src';
 
 describe('Collection', () => {

--- a/test/test-snapshot.js
+++ b/test/test-snapshot.js
@@ -1,5 +1,5 @@
 import assert from 'power-assert';
-import most from 'most';
+import * as most from 'most';
 import Collection from '../src';
 import switchCollection from '../src/switch-collection';
 import snapshot from '../src/snapshot';

--- a/test/test-switch-collection.js
+++ b/test/test-switch-collection.js
@@ -1,5 +1,5 @@
 import assert from 'power-assert';
-import most from 'most';
+import * as most from 'most';
 import Collection from '../src';
 import switchCollection from '../src/switch-collection';
 import {placeholderSymbol} from '../src/common';


### PR DESCRIPTION
Simple fix that brings compatibility with babel 6 (ES6 modules).

``` javascript
import most from 'most';
```
into
``` javascript
import * as most from 'most';
```
Preferably one would do named imports ` import { just } from 'most' `.